### PR TITLE
Replace `PROTOCOL_SSLv2` with `PROTOCOL_TLS` because SSLv2 is deprecated & insecure

### DIFF
--- a/client/main.py
+++ b/client/main.py
@@ -28,7 +28,7 @@ class Client:
     def initClientSocket(self):
         # Code Section
         sock = socket.socket(socket.AF_INET,socket.SOCK_STREAM) # Create socket using Ipv4 family and TCP protocol
-        self.clientFD = ssl.wrap_socket(sock, certfile="client.pem", keyfile="client.key", ssl_version=ssl.PROTOCOL_SSLv2)
+        self.clientFD = ssl.wrap_socket(sock, certfile="client.pem", keyfile="client.key", ssl_version=ssl.PROTOCOL_TLS)
         self.clientFD.connect((self.serverIP, self.serverPort))          # Connect to remote server
         Utilities.logger('Client socket connected Successfully')
 

--- a/server/main.py
+++ b/server/main.py
@@ -59,7 +59,7 @@ class Server:
         while(True):
             client, address = self.serverFD.accept()     # Accept new connection
             secure_socket   = ssl.wrap_socket(client, server_side=True, ca_certs = "client.pem", certfile="server.pem", keyfile="server.key",
-                                              cert_reqs=ssl.CERT_REQUIRED, ssl_version=ssl.PROTOCOL_SSLv2)
+                                              cert_reqs=ssl.CERT_REQUIRED, ssl_version=ssl.PROTOCOL_TLS)
 
             Utilities.logger("Accepted new connection from " + address[0])
 


### PR DESCRIPTION
Replace `PROTOCOL_SSLv2` with `PROTOCOL_TLS` because SSLv2 is **deprecated & insecure** look at the [Python docs](https://docs.python.org/2.7/library/ssl.html#ssl.PROTOCOL_SSLv2)
